### PR TITLE
Add support for interface name in cloud-init

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -264,7 +264,9 @@ core::create_cloud_init(){
     mkdir -p "${_cloud_init_dir}"
 
     if [ -n "${_network_config}" ]; then
-        # Example netconfig param: "ip=10.0.0.2/24;gateway=10.0.0.1;nameservers=1.1.1.1,8.8.8.8"
+        # Example netconfig param: "interface=vtnet0;ip=10.0.0.2/24;gateway=10.0.0.1;nameservers=1.1.1.1,8.8.8.8"
+        _network_config_interface="$(echo "${_network_config}" | \
+            grep -oE 'interface=[^;]*' | sed 's/^interface=//')";
         _network_config_ipaddress="$(echo "${_network_config}" | \
             grep -oE 'ip=[^;]*' | sed 's/^ip=//')"
         _network_config_gateway="$(echo "${_network_config}" | \
@@ -283,7 +285,7 @@ core::create_cloud_init(){
 version: 2
 ethernets:
   id0:
-    set-name: eth0
+    set-name: ${_network_config_interface:-eth0}
     match:
       macaddress: "${_mac}"
     addresses:


### PR DESCRIPTION
Implements churchers/vm-bhyve#559, rework of churchers/vm-bhyve#560 to resolve conflicts.