### PR TITLE
Update funding link to FreeBSD Foundation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: #freebsd-vm-bhyve
+open_collective: the-freebsd-foundation1
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
I confirmed that the Collective is official: https://opencollective.com/the-freebsd-foundation1
