### PR TITLE
Add bootindex=1 to "vm install {name} {iso}" (#20)

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -198,7 +198,7 @@ vm::run(){
         # add install iso or disk image
         if [ -n "${_iso}" ]; then
             if echo "${_iso}" | grep -iqs '.iso$'; then
-                _iso_dev="-s ${_install_slot}:0,ahci-cd,${_iso},ro"
+                _iso_dev="-s ${_install_slot}:0,ahci-cd,${_iso},ro,bootindex=1"
             else
                 _iso_dev="-s ${_install_slot}:0,ahci-hd,${_iso},ro"
             fi


### PR DESCRIPTION
Prioritize ahci-cd with a bootable ISO over other devices to avoid fiddling with boot options.

This fixes #20