### PR TITLE
Use a private socket with tmux.

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -24,6 +24,8 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+TMUX_SOCKET=/var/run/vm-bhyve.sock
+
 # 'vm list'
 # list virtual machines
 #
@@ -704,6 +706,8 @@ core::__start(){
         return 1
     fi
 
+    _tmux_cmd="$_tmux_cmd -S $TMUX_SOCKET"
+
     echo "  * booting..."
 
     # run background process to actually start bhyve
@@ -928,7 +932,8 @@ core::console(){
         _tmux_cmd=$(which tmux)
 
         if [ -n "${_tmux_cmd}" ]; then
-            _tmux=$("${_tmux_cmd}" ls |grep "^${_name}:")
+            _tmux_cmd="$_tmux_cmd -S $TMUX_SOCKET"
+            _tmux=$(${_tmux_cmd} ls |grep "^${_name}:")
 
             if [ -n "${_tmux}" ]; then
                 ${_tmux_cmd} attach -t ${_console##*/}


### PR DESCRIPTION
This patch uses a private (/var/run/vm-bhyve.sock) socket (and therefore tmux server process) when tmux is enabled rather than sharing with the root user. (For actions like tmux list or tmux attach.)

Note that this update requires shutting down and restarting VMs to be able to attach to them. (Since a running VM pre-update will still be sharing root's tmux server.)