### PR TITLE
Add -w option to wait until VM starts before connecting to console

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -923,6 +923,7 @@ core::console(){
     datastore::get_guest "${_name}" || util::err "${_name} doesn't appear to be a valid virtual machine"
 
     if [ -n "${_wait_for_vm}" ]; then
+        echo "Waiting for ${_name} to start..."
         # wait for the VM to start; /dev/vmm/${_name} usually appears within 50 ms
         sleep 0.05
         while [ ! -e "/dev/vmm/${_name}" ]; do

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -903,14 +903,34 @@ core::rename(){
 # @param string _port the port to connect to (default = first in configuration)
 #
 core::console(){
-    local _name="$1"
-    local _port="$2"
-    local _console _tmux _tmux_cmd
+    local _name _port
+    local _console _tmux _tmux_cmd _wait_for_vm
+
+    while getopts w _opt ; do
+        case $_opt in
+            w) _wait_for_vm="1" ;;
+            *) util::usage ;;
+        esac
+    done
+
+    shift $((OPTIND - 1))
+
+    _name="$1"
+    _port="$2"
 
     [ -z "${_name}" ] && util::usage
 
     datastore::get_guest "${_name}" || util::err "${_name} doesn't appear to be a valid virtual machine"
-    [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
+
+    if [ -n "${_wait_for_vm}" ]; then
+        # wait for the VM to start; /dev/vmm/${_name} usually appears within 50 ms
+        sleep 0.05
+        while [ ! -e "/dev/vmm/${_name}" ]; do
+            sleep 1
+        done
+    else
+        [ ! -e "/dev/vmm/${_name}" ] && util::err "${_name} doesn't appear to be a running virtual machine"
+    fi
 
     if [ -e "${VM_DS_PATH}/${_name}/console" ]; then
 

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -168,7 +168,7 @@ Usage: vm ...
     start [-fi] <name> [...]
     stop <name> [...]
     restart <name>
-    console <name> [com1|com2]
+    console [-w] <name> [com1|com2]
     configure <name>
     rename <name> <new-name>
     add [-d device] [-t type] [-s size|switch] <name>

--- a/vm.8
+++ b/vm.8
@@ -111,6 +111,7 @@
 .Ar name
 .Nm
 .Cm console
+.Op Fl w
 .Ar name
 .Op Ar com1|com2
 .Nm
@@ -770,7 +771,12 @@ it would when using
 .Sy stop/start .
 Note that guest configuration is not re-loaded, so all guest settings will be as they were
 when the guest was originally started.
-.It Cm console Ar name Op Ar com1|com2
+.It Xo
+.Cm console
+.Op Fl w
+.Ar name
+.Op Ar com1|com2
+.Xc
 Connect to the console of the named virtual machine.
 Without network access, this is the primary way of connecting to the guest once
 it is running.
@@ -784,6 +790,11 @@ This looks for the
 device associated with the virtual machine, and connects to it with
 .Xr cu 1 .
 Use ~+Ctrl-D to exit the console and return to the host.
+.Pp
+If the
+.Ar -w
+option is specified, wait until the virtual machine starts before connecting
+to the console.
 .It Cm rename Ar name Ar new-name
 Renames the specified virtual machine.
 The guest must be stopped to use this function.


### PR DESCRIPTION
This change addresses an issue connecting to the console right after starting the VM. For example:

```
# vm start freebsd && vm console freebsd
Starting freebsd
  * found guest in /bhyve/freebsd
  * booting...
/usr/local/sbin/vm: ERROR: freebsd doesn't appear to be a running virtual machine
```