### PR TITLE
Add auto_linklocal option to the IPv6 bridge.

### DIFF
--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -59,7 +59,7 @@ switch::standard::init(){
     config::core::get "_addr" "addr_${_name}"
     [ -n "${_addr}" ] && ifconfig "${_id}" inet ${_addr} 2>/dev/null
     config::core::get "_addr" "addr6_${_name}"
-    [ -n "${_addr}" ] && ifconfig "${_id}" inet6 ${_addr} 2>/dev/null
+    [ -n "${_addr}" ] && ifconfig "${_id}" inet6 ${_addr} auto_linklocal 2>/dev/null
 
     # custom mtu?
     config::core::get "_mtu" "mtu_${_name}"


### PR DESCRIPTION
I'm using dnsmasq to assign IPs to machines. It can also send router advertisement messages allowing to use SLAAC in VMs to get IPv6 addresses.

AFAIK these advertisement messages MUST be sent using link local IPv6 addresses to be conformant, otherwise OSes ignore them.

In FreebSD bridge(4) interfaces by default have no link local addresses.

Adding the auto_linklocal causes the interface to autoassign a valid link local address, so SLAAC works properly.

I suggest enabling this unconditionally, I don't see any ill effects this could cause, considering the bridge is used as a swtich.

NOTE: I used to have the same PR active on the old repository, I'm sending it again here, hoping it can be evaluated.