### PR TITLE
Alias edit subcommand to configure

### DIFF
--- a/lib/vm-cmd
+++ b/lib/vm-cmd
@@ -26,7 +26,7 @@
 
 CMD_VALID_LIST="init,switch,datastore,image,get,set,list,create,destroy,rename,install,start,stop,restart"
 CMD_VALID_LIST="${CMD_VALID_LIST},add,reset,poweroff,startall,stopall,console,iso,img,configure,passthru,_run"
-CMD_VALID_LIST="${CMD_VALID_LIST},info,clone,snapshot,rollback,migrate,version,usage"
+CMD_VALID_LIST="${CMD_VALID_LIST},info,clone,snapshot,rollback,migrate,version,usage,edit"
 
 # cmd: vm ...
 #
@@ -83,7 +83,7 @@ cmd::parse(){
         console)   core::console "$@" ;;
         iso)       core::iso "$@" ;;
         img)       core::img "$@" ;;
-        configure) core::configure "$@" ;;
+        configure|edit) core::configure "$@" ;;
         passthru)  core::passthru ;;
         _run)      vm::run "$@" ;;
         info)      info::guest "$@" ;;

--- a/lib/vm-util
+++ b/lib/vm-util
@@ -170,6 +170,7 @@ Usage: vm ...
     restart <name>
     console [-w] <name> [com1|com2]
     configure <name>
+    edit <name>
     rename <name> <new-name>
     add [-d device] [-t type] [-s size|switch] <name>
     startall

--- a/vm.8
+++ b/vm.8
@@ -141,6 +141,9 @@
 .Cm configure
 .Ar name
 .Nm
+.Cm edit
+.Ar name
+.Nm
 .Cm passthru
 .Nm
 .Cm clone
@@ -893,6 +896,8 @@ subcommand simply opens the virtual machine configuration file in your default
 editor, allowing you to easily make changes.
 Please note, changes do not take effect until the virtual machine is fully
 shutdown and restarted.
+.It Cm edit Ar name
+An alias to the configure subcommand.
 .It Cm passthru
 The
 .Cm passthru


### PR DESCRIPTION
This comes down to my personal preference so I'm not sure if everyone will like it, but I'd like to add it unless there are any objections. 

I'm also using [bastille](https://github.com/BastilleBSD/bastille) for jail manager on the same host as vm-bhyve. vm-bhyve and bastille have a very similar command set but there is a bit difference. `configure` in vm-bhyve corresponds to `edit` in bastille.  Adding `edit` subcommand that aliases to `configure` to vm-bhyve makes it easier to switch between the two tools. 

Just adding an alias, not changing the current command or behaviour.