### PR TITLE
Do not error when removing the saved state on stop or poweroff

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -940,11 +940,16 @@ core::discard(){
     fi
 
     if [ ! -e "${VM_DS_PATH}/${_name}/${_name}.save" ]; then
-        util::err "no saved state exists for ${_name}"
+        if [ -z "${VM_OPT_FORCE}" ]; then
+            util::err "no saved state exists for ${_name}"
+        else
+            # When VM_OPT_FORCE is set, do not error if no saved state exists
+            return 0
+        fi
     fi
 
     # remove vm state file
-    rm \
+    rm -- \
         "${VM_DS_PATH}/${_name}/${_name}.save*" \
 
     exit $?


### PR DESCRIPTION
for a cold-booted VM.


The changes for suspend/resume unintendedly affected cold-boot/cold-shutdown of a VM.