### PR TITLE
Allow editing cloud-init config via `vm configure` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ To list downloaded images:
 vm-bhyve has basic support for providing cloud-init configuration to the guest. You can enable it with `-C` option
 to `vm create` command. You can also pass public SSH key to be injected into the guest with option `-k <file>`.
 The public key file can contain multiple public SSH keys, one per line, in the `authorized_keys` format.
+
 Also `vm create` has option `-n "interface=;ip=;gateway=;nameservers=;searchdomains=;hostname="` that allows to set network parameters.
 Example netconfig param: "interface=vtnet0;ip=10.0.0.2/24;gateway=10.0.0.1;nameservers=1.1.1.1,8.8.8.8;searchdomains=example.com,example.org" .
 
@@ -295,6 +296,14 @@ Example:
     Are you sure you want to continue connecting (yes/no)? yes
     Warning: Permanently added '192.168.0.91' (ECDSA) to the list of known hosts.
     Welcome to Ubuntu 16.04.5 LTS (GNU/Linux 4.4.0-141-generic x86_64)
+
+### Editing cloud-init configuration
+To edit generated cloud-init configuration files, such as meta-data, network-config and user-data, specify the configuration file for the `vm configure` command.
+Please note that cloud-init typically runs only on the first boot. Any changes made after the first boot does not take effect.
+
+```
+# vm configure <name> user-data
+```
 
 ## Adding custom disks
 

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -1038,6 +1038,7 @@ core::console(){
 #
 core::configure(){
     local _name="$1"
+    local _target="$2"
 
     [ -z "${_name}" ] && util::usage
     [ -z "${EDITOR}" ] && EDITOR="vi"
@@ -1045,7 +1046,24 @@ core::configure(){
     datastore::get_guest "${_name}" || \
         util::err "cannot locate configuration file for virtual machine: ${_name}"
 
-    $EDITOR "${VM_DS_PATH}/${_name}/${_name}.conf"
+    case "$_target" in
+        meta-data|network-config|user-data)
+            [ -d "${VM_DS_PATH}/${_name}/.cloud-init" ] || \
+                util::err "cloud-init is not enabled for this guest"
+            if [ -e "${VM_DS_PATH}/${_name}/seed.iso" ]; then
+                util::confirm "cloud-init has run already. changes won't take effect. edit anyway?" || exit 0
+            fi
+
+            $EDITOR "${VM_DS_PATH}/${_name}/.cloud-init/${_target}"
+            ;;
+        "")
+            $EDITOR "${VM_DS_PATH}/${_name}/${_name}.conf"
+            ;;
+        *)
+            util::usage
+            ;;
+    esac
+
 }
 
 # 'vm iso'

--- a/vm.8
+++ b/vm.8
@@ -142,9 +142,11 @@
 .Nm
 .Cm configure
 .Ar name
+.Op Ar meta-data|network-config|user-data
 .Nm
 .Cm edit
 .Ar name
+.Op Ar meta-data|network-config|user-data
 .Nm
 .Cm passthru
 .Nm
@@ -898,14 +900,17 @@ This sends a stop command to all
 instances, regardless of whether they were starting using
 .Nm
 or not.
-.It Cm configure Ar name
+.It Cm configure Ar name Op Ar meta-data|network-config|user-data
 The
 .Cm configure
 subcommand simply opens the virtual machine configuration file in your default
 editor, allowing you to easily make changes.
 Please note, changes do not take effect until the virtual machine is fully
 shutdown and restarted.
-.It Cm edit Ar name
+.Pp
+If a second argument is given, it opens the specified cloud-init configuration
+file in the default editor.
+.It Cm edit Ar name Op Ar meta-data|network-config|user-data
 An alias to the configure subcommand.
 .It Cm passthru
 The


### PR DESCRIPTION
This helps reviewing & editing cloud-init configurations generated by `vm create -C -k <pubkey> -n <netconfig>`.

Examples:

    # vm configure <name> meta-data
    # vm configure <name> network-config
    # vm configure <name> user-data