### PR TITLE
Add proper handling for renaming and cloning suspended VMs

### DIFF
--- a/lib/vm-core
+++ b/lib/vm-core
@@ -941,6 +941,7 @@ core::discard(){
 core::rename(){
     local _old="$1"
     local _new="$2"
+    local _mv_failed
 
     [ -z "${_old}" -o -z "${_new}" ] && util::usage
     util::check_name "${_new}" || util::err "invalid virtual machine name - '${_name}'"
@@ -963,6 +964,17 @@ core::rename(){
     # rename config file
     mv "${VM_DS_PATH}/${_new}/${_old}.conf" "${VM_DS_PATH}/${_new}/${_new}.conf" >/dev/null 2>&1
     [ $? -eq 0 ] || util::err "changed guest directory but failed to rename configuration file"
+
+    # rename saved vm state file
+    _mv_failed=0
+    (
+        cd "${VM_DS_PATH}/${_new}" || exit 1
+        find . -type f -depth 1 -name "${_old}.save*" | while read -r oldf; do
+            newf="$(echo "${oldf}" | sed "s|${_old}|${_new}|" )"
+            echo mv "${oldf} ${newf}" || _mv_failed=1
+        done
+    )
+    [ "${_mv_failed}" -eq 0 ] || util::err "changed guest directory but failed to rename saved vm state file"
 }
 
 # 'vm console'

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -927,8 +927,7 @@ core::discard(){
     fi
 
     # remove vm state file
-    rm -- \
-        "${VM_DS_PATH}/${_name}/${_name}.save*" \
+    find "${VM_DS_PATH}/${_name}" -name "${_name}.save*" -type f -delete
 
     exit $?
 }

--- a/lib/vm-core
+++ b/lib/vm-core
@@ -689,7 +689,7 @@ core::__start(){
         return 1
     fi
 
-    if util::check_bhyve_suspend >/dev/null 2>&1 && [ -e "${VM_DS_PATH}/${_name}/${_name}.save" ]; then
+    if util::check_bhyve_suspend >/dev/null 2>&1 && vm::has_saved_state "${_name}"; then
         echo "  * found saved vm state, resuming..."
     else
         echo "  * booting..."
@@ -917,7 +917,7 @@ core::discard(){
         util::confirm "Are you sure you want to remove the saved state of this virtual machine" || exit 0
     fi
 
-    if [ ! -e "${VM_DS_PATH}/${_name}/${_name}.save" ]; then
+    if ! vm::has_saved_state "${_name}"; then
         if [ -z "${VM_OPT_FORCE}" ]; then
             util::err "no saved state exists for ${_name}"
         else

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -214,7 +214,7 @@ vm::run(){
 
         # resume if saved vm state found
         set -- ${_opts} # convert _opts to a positional parameter
-        if [ -e "${VM_DS_PATH}/${_name}/${_name}.save" ]; then
+        if vm::has_saved_state "${_name}"; then
             if util::check_bhyve_suspend; then
                 util::log "guest" "${_name}" "saved vm state found, resuming"
                 # there is no safe way to store a file path containing spaces in a string variable
@@ -943,7 +943,7 @@ vm::running_check(){
 
     datastore::get_guest "${_name}"
 
-    if [ -e "${VM_DS_PATH}/${_name}/${_name}.save" ]; then
+    if vm::has_saved_state "${_name}"; then
         setvar "${_var}" "Suspended"
     else
         setvar "${_var}" "Stopped"
@@ -987,6 +987,19 @@ vm::confirm_stopped(){
     fi
 
     return 0
+}
+
+#
+# check if the virtual machine has saved state
+#
+# @param string _name the guest name
+# @return success if the guest has saved state
+#
+vm::has_saved_state(){
+    local _name="$1"
+
+    [ -e "${VM_DS_PATH}/${_name}/${_name}.save" ]
+    return $?
 }
 
 # generate a static mac address for a guest.

--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -267,6 +267,7 @@ zfs::clone(){
     # generate a short uuid and create snapshot if no custom snap given
     if [ -z "${_snap}" ]; then
         vm::confirm_stopped "${_old}" || exit 1
+        vm::has_saved_state "${_old}" && util::err "guest appears to be suspended, stop it before cloning"
         _snap=$(echo "${_uuid}" |awk -F- '{print $1}')
 
         zfs snapshot -r "${VM_DS_ZFS_DATASET}/${_old}@${_snap}"


### PR DESCRIPTION
Suspended VMs are now properly handled in rename and clone operations.

- Prohibit cloning suspended VMs to avoid MAC address conflicts
- Also rename saved state file when renaming VM 

While here, 
- Fix globbing in core::discard
- Refactor saved state file existence check into a function