### PR TITLE
README: grub is not necessary to run Linux guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Some of the main features include:
 
 ** Some additional packages may be required in certain circumstances -
 
-* `sysutils/grub2-bhyve` is required to run Linux or any other guests that need a Grub bootloader.
+* `sysutils/grub2-bhyve` is required to run guests that need a Grub bootloader
 * `sysutils/bhyve-firmware` is required to run UEFI guests
 * `sysutils/tmux` is needed to use tmux console access instead of cu/nmdm
 


### PR DESCRIPTION
Some people still misunderstand that grub2-bhyve is necessary to run Linux guests, as seen in #11 or #33. Therefore, I'm updating the README.

It may sound tautological, but grub2-bhyve is required to run guests that actually require grub. In most cases, `loader="uefi"` is sufficient to boot Linux guests nowadays.