### PR TITLE
Use sane date format in `vm image list`

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -325,7 +325,7 @@ zfs::image_create(){
     _name=$1
     _uuid=$(uuidgen)
     _snap=${_uuid%%-*}
-    _date=$(date)
+    _date=$(date -Iseconds)
 
     [ -z "${_desc}" ] && _desc="No description provided"
 


### PR DESCRIPTION
Same with #23, localization is not needed here.

```
# vm image list
UUID                                  NAME        CREATED                                 DESCRIPTION
06a19c9b-9371-11f0-8655-98b78501ef2a  freebsd-14  2025年 9月17日 水曜日 11時50分10秒 JST  test
62020b1d-937c-11f0-8655-98b78501ef2a  freebsd-14  2025-09-17T13:11:27+09:00               test2
```