### PR TITLE
Accept options for passthru devices

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -795,18 +795,19 @@ vm::bhyve_device_console(){
 # @modifies _devices _slot _bus _opts _wiredmem
 #
 vm::bhyve_device_passthru(){
-    local _dev _orig_slot _func=0
+    local _dev _options _orig_slot _func=0
     local _last_orig_slot
     local _num=0
 
     while true; do
         config::get "_dev" "passthru${_num}"
+        config::get "_options" "passthru${_num}_options"
         [ -z "${_dev}" ] && break
 
         # see if there's an = sign
         # we allow A/B/C=D:E to force D:E as the guest SLOT:FUNC
         if echo "${_dev}" | grep -qs "="; then
-            _devices="${_devices} -s ${_bus}:${_dev##*=},passthru,${_dev%%=*}"
+            _devices="${_devices} -s ${_bus}:${_dev##*=},passthru,${_dev%%=*}${_options:+,${_options}}"
         else
             _orig_slot=${_dev%%/*}
 
@@ -824,7 +825,7 @@ vm::bhyve_device_passthru(){
 	    _maxslots=32
         fi
 
-            _devices="${_devices} -s ${_bus}:${_slot}:${_func},passthru,${_dev}"
+            _devices="${_devices} -s ${_bus}:${_slot}:${_func},passthru,${_dev}${_options:+,${_options}}"
             _last_orig_slot=${_orig_slot}
             _func=$((_func + 1))
         fi

--- a/vm.8
+++ b/vm.8
@@ -1555,6 +1555,19 @@ same sequence as the original device.
 Please see
 .Lk https://wiki.freebsd.org/bhyve/pci_passthru
 for more details on how this works.
+.It Cm passthruX_options
+Specify options for a passthru device backend such as
+.Sy rom
+and
+.Sy bootindex .
+.Pp
+For example, to use a ROM file with the first passthru device:
+.Pp
+passthru0_options="rom=i915_vbt"
+.Pp
+Please see the
+.Xr bhyve 8
+man page for more details on passthru-device-options.
 .It virt_random
 Set this option to
 .Sy yes


### PR DESCRIPTION
Passthru device backends can take options such as rom and bootindex.
Add passthruX_options setting to accept those.