### PR TITLE
Accept extra settings to pass to bhyve

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -16,7 +16,7 @@ vm::run(){
     local _guest_support _uefi _uuid _debug _hostbridge _fwcfg _loader
     local _opts _devices _slot _bus=0 _maxslots=31 _install_slot _func=0 _taplist _exit _passdev
     local _com _comports _comstring _logpath="/dev/null" _run=1
-    local _bhyve_options _action
+    local _bhyve_options _bhyve_extra _action
 
     cmd::parse_args "$@"
     shift $?
@@ -45,6 +45,7 @@ vm::run(){
     config::get "_uuid" "uuid"
     config::get "_debug" "debug" "no"
     config::get "_bhyve_options" "bhyve_options"
+    config::get "_bhyve_extra" "bhyve_extra"
     config::get "_slot" "start_slot" "4"
     config::get "_install_slot" "install_slot" "3"
 
@@ -232,7 +233,8 @@ vm::run(){
 
         util::log "guest" "${_name}" " [bhyve options: $*]" \
           " [bhyve devices: ${_devices}]" \
-          " [bhyve console: ${_comstring}]"
+          " [bhyve console: ${_comstring}]" \
+          " [bhyve extra: ${_bhyve_extra}]"
         [ -n "${_iso_dev}" ] && util::log "guest" "${_name}" " [bhyve iso device: ${_iso_dev}]"
         util::log "guest" "${_name}" "starting bhyve (run ${_run})"
 
@@ -245,6 +247,7 @@ vm::run(){
               ${_devices} \
               ${_iso_dev} \
               ${_comstring} \
+              ${_bhyve_extra} \
               ${_name} 2> "${_logpath}"
 
         # get bhyve exit code

--- a/vm.8
+++ b/vm.8
@@ -1490,6 +1490,22 @@ Specify any additional command line arguments to pass to the bhyve command.
 This allows the use of options such as cpu pinning or debug that are not
 exposed by
 .Sy vm-bhyve .
+.It bhyve_extra
+Similar to the
+.Sy bhyve_options
+setting, specify any additional command line arguments to pass to the bhyve
+command, but at the end of the command.
+.Pp
+bhyve can be dependent upon the order of the options it receives, so attempting
+to set configuration variables using
+.Sy -k
+or
+.Sy -o
+from
+.Xr bhyve 8
+will result in an error if set prior to setting the PCI slot (bhyve
+.Sy -s
+option).
 .It grub_installX
 This option allows you to specify grub commands needed to boot the install
 media for this guest.


### PR DESCRIPTION
bhyve can be dependent upon the order of the options it receives, so add
a setting similar to bhyve_options, called bhyve_extra, that is passed
to bhyve as the last options.

"-s 31,lpc" is passed by vm-bhyve after the options provided by
bhyve_options.  However, this causes bhyve to return an error when
attempting to use GPU passthru with an Intel iGPU due to additional
options needing to be passed.

Sample error:
$ bhyve ... -o pci.0.31.0.pcireg.vendor=host -s 31,lpc ...
pci slot 0:31:0 already occupied!