### PR TITLE
Switch master branch to 1.8-devel

### DIFF
--- a/lib/vm-base
+++ b/lib/vm-base
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # SPDX-FileCopyrightText: 2018 Matt Churchyard <churchers@gmail.com>
 
-VERSION=1.7.0
+VERSION=1.8-devel
 VERSION_BSD=$(uname -K)
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 


### PR DESCRIPTION
v1.7.0 has been released. The master branch will now transition to 1.8-devel for development toward the future v1.8.0 release.

The v1.7.x series will be released from the 1.7-stable branch. Selected commits from master that are useful and do not compromise stability will be cherry-picked into 1.7-stable and included in the upcoming v1.7.x releases.