### PR TITLE
Increase memory to 512M for freebsd template

### DIFF
--- a/sample-templates/default.conf
+++ b/sample-templates/default.conf
@@ -1,6 +1,6 @@
 loader="bhyveload"
 cpu=1
-memory=256M
+memory=512M
 network0_type="virtio-net"
 network0_switch="public"
 disk0_type="virtio-blk"


### PR DESCRIPTION
Hello,

I was just doing a fresh install of freebsd inside a vm (host also freebsd) and noticed that the install did not complete successfully. The installer always crashed while installing the base system via pkg (I'm using the pkgbase path) and could not install the system after multiple attempts.

Increasing the memory for the VM resolved the issue and the vm got installed on the first attempt.

I assume the pkgbase install has a bit more resource requirements than the traditional set way, so it'd probably be appropriate to increase the default value here accordingly. I can also hardly imagine any scenario where 256M is a hard limit for anyone doing virtualization.