### PR TITLE
Read LIB from DESTDIR instead of hardcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ MAN=$(PROG).8
 install:
 	$(MKDIR) -p $(BINDIR)
 	$(INSTALL) -m 544 $(PROG) $(BINDIR)/
+	sed -i '' -e 's|/usr/local/lib/vm-bhyve|$(LIBDIR)|g' $(BINDIR)/$(PROG)
 
 	$(MKDIR) -p $(LIBDIR)
 	$(INSTALL) lib/* $(LIBDIR)/


### PR DESCRIPTION
vm hardcodes the lib path to /usr/local/lib/vm-bhyve, which may not match where it's installed with `make install`.