### PR TITLE
Support booting from 9pfs

### DIFF
--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -57,6 +57,15 @@ guest::load(){
 
             if [ -n "${_iso}" ]; then
                 _args="${_args} -d ${_iso}"
+            elif [ "${_bootdisk_dev}" = "9p" ]; then
+                local p9dev p9path
+                p9dev=$(echo "${_bootdisk}" | awk -F = '{print $1}')
+                p9path=$(echo "${_bootdisk}" | awk -F = '{print $2}')
+                if [ -z "${p9dev}" -o -z "${p9path}" ]; then
+                    util::log "guest" "${_name}" "fatal; virtio-9p boot disk requires format devname=/path/to/root"
+                    return 15
+                fi
+                _args="${_args} -h ${p9path} -e vfs.root.mountfrom=p9fs:${p9dev}"
             else
                 _args="${_args} -d ${_bootdisk}"
             fi

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -871,7 +871,7 @@ vm::get_disk_path(){
     case "${_disk_dev}" in
         zvol)        ;&
         sparse-zvol) setvar "${_var}" "/dev/zvol/${VM_DS_ZFS_DATASET}/${_name}/${_disk}" ;;
-        custom)      setvar "${_var}" "${_disk}" ;;
+        custom|9p)   setvar "${_var}" "${_disk}" ;;
         iscsi)       info::__find_iscsi "${_var}" "${_disk}" ;;
         *)           setvar "${_var}" "${VM_DS_PATH}/${_name}/${_disk}" ;;
     esac

--- a/vm.8
+++ b/vm.8
@@ -1480,6 +1480,7 @@ or
 (which will use a ZVOL as the disk image, created directly under the guest
 dataset),
 .Sy custom ,
+.Sy 9p ,
 and
 .Sy iscsi .
 .Pp


### PR DESCRIPTION
Example config:

    disk0_type="virtio-9p"
    disk0_name="devroot=/vm/p9-test/p9-root"
    disk0_dev="9p"

It also requires 9pfs root /boot/loader.conf to have:

    virtio_p9fs_load="YES"