### PR TITLE
Add support for IPv6 on Standard Switch

### DIFF
--- a/lib/vm-cmd
+++ b/lib/vm-cmd
@@ -99,7 +99,7 @@ cmd::parse_switch(){
     local _cmd
 
     # try to find a matching command
-    cmd::find "_cmd" "$1" "create,list,destroy,add,remove,vlan,nat,address,private,info" || util::usage
+    cmd::find "_cmd" "$1" "create,list,destroy,add,remove,vlan,nat,address,address6,private,info" || util::usage
     shift
 
     case "${_cmd}" in
@@ -111,6 +111,7 @@ cmd::parse_switch(){
         vlan)    switch::vlan "$@" ;;
         nat)     switch::nat "$@" ;;
         address) switch::address "$@" ;;
+        address6) switch::address6 "$@" ;;
         private) switch::private "$@" ;;
         info)    info::switch "$@" ;;
         *)       util::err "unknown command '${_user_cmd}'. please run 'vm usage' or view the manpage for help" ;;

--- a/lib/vm-help
+++ b/lib/vm-help
@@ -54,6 +54,7 @@ Usage:
     vm switch vlan <name> <on|off>
     vm switch nat <name> <on|off>
     vm switch address name <a.b.c.d/xx|none>
+    vm switch address6 name <a:b:c:d::x/xx|none>
     vm switch private <name> <on|off>
     vm switch add <name> <interface>
     vm switch remove <name> <interface>
@@ -65,6 +66,7 @@ Options:
     -i <interface>  Interface to attach to the switch
     -m <size>       MTU size of the switch
     -a <address>    IP address (CIDR notation) assigned to bridge interface
+    -6 <ipv6>		IPv6 address (CIDR notation) assigned to bridge interface
     -b <bridge>     Specify an existing bridge when creating a manual switch
     -p              Create a private switch
 "

--- a/lib/vm-switch
+++ b/lib/vm-switch
@@ -40,12 +40,12 @@ switch::init(){
 #
 switch::list(){
     local _switchlist _switch _type
-    local _id _format="%s^%s^%s^%s^%s^%s^%s^%s\n"
+    local _id _format="%s^%s^%s^%s^%s^%s^%s^%s^%s\n"
 
     config::core::get "_switchlist" "switch_list"
 
     {
-        printf "${_format}" "NAME" "TYPE" "IFACE" "ADDRESS" "PRIVATE" "MTU" "VLAN" "PORTS"
+        printf "${_format}" "NAME" "TYPE" "IFACE" "ADDRESS" "ADDRESS6" "PRIVATE" "MTU" "VLAN" "PORTS"
 
         if [ -n "${_switchlist}" ]; then
             for _switch in ${_switchlist}; do
@@ -71,16 +71,17 @@ switch::list(){
 switch::create(){
     local _switch
     local _type="standard"
-    local _list _curr _vlan _if _bridge _addr _mtu _priv
+    local _list _curr _vlan _if _bridge _addr _addr6 _mtu _priv
 
     # process options
-    while getopts t:i:n:b:a:m:p _opt; do
+    while getopts t:i:n:b:a:6:m:p _opt; do
         case ${_opt} in
             t) _type="${OPTARG}" ;;
             i) _if="${OPTARG}" ;;
             n) _vlan="${OPTARG}" ;;
             b) _bridge="${OPTARG}" ;;
             a) _addr="${OPTARG}" ;;
+            6) _addr6="${OPTARG}" ;;
             m) _mtu="${OPTARG}" ;;
             p) _priv="yes" ;;
             *) util::usage ;;
@@ -111,6 +112,12 @@ switch::create(){
     if [ -n "${_addr}" ]; then
         echo "${_addr}" | egrep -qs '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}$'
         [ $? -eq 0 ] || util::err "address must be supplied in CIDR notation (a.b.c.d/prefix-len)"
+    fi
+
+    # check ipv6 address
+    if [ -n "${_addr6}" ]; then
+        echo "${_addr6}" | egrep -qs '(::)?[0-9a-fA-F]{1,4}(::?[0-9a-fA-F]{1,4}){1,7}(::)?\/[0-9]{1,3}'
+        [ $? -eq 0 ] || util::err "address6 must be supplied in CIDR notation (e.g. 2001:1a:2b:3c:4d::1/64)"
     fi
 
     # check mtu
@@ -158,7 +165,7 @@ switch::remove(){
     if [ $? -eq 0 ]; then
         config::core::remove "switch_list" "${_switch}"
         config::core::remove "ports_${_switch} vlan_${_switch} nat_${_switch} type_${_switch}"
-        config::core::remove "addr_${_switch} private_${_switch} mtu_${_switch}"
+        config::core::remove "addr_${_switch} addr6_${_switch} private_${_switch} mtu_${_switch}"
     else
         util::err "failed to remove virtual switch"
     fi
@@ -319,6 +326,38 @@ switch::address(){
 
     case "${_type}" in
         standard) switch::standard::address "${_switch}" "${_addr}" ;;
+        manual)   ;&
+        netgraph) ;&
+        vale)     ;&
+        vxlan)    util::err "feature not currently supported on switches of this type" ;;
+        *)        util::err "unable to configure switch of unknown type" ;;
+    esac
+}
+
+# set or remove ipv6 address from a virtual switch
+#
+# @param string _switch name of the switch
+# @param string _addr6 the ip address to add (or "none" to remove)
+#
+switch::address6(){
+    local _switch="$1"
+    local _addr6="$2"
+    local _id _type
+
+    [ -z "${_switch}" ] && util::usage
+
+    switch::id "_id" "${_switch}"
+    switch::type "_type" "${_switch}"
+    [ -z "${_id}" ] && util::err "unable to locate specified virtual switch"
+
+    # check address
+    if [ -n "${_addr6}" ] && [ "${_addr6}" != "none" ]; then
+        echo "${_addr6}" | egrep -qs '(::)?[0-9a-fA-F]{1,4}(::?[0-9a-fA-F]{1,4}){1,7}(::)?\/[0-9]{1,3}'
+        [ $? -eq 0 ] || util::err "address6 must be supplied in CIDR notation (e.g. 2001:1a:2b:3c:4d::1/64)"
+    fi
+
+    case "${_type}" in
+        standard) switch::standard::address6 "${_switch}" "${_addr6}" ;;
         manual)   ;&
         netgraph) ;&
         vale)     ;&

--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -55,16 +55,17 @@ switch::standard::init(){
 switch::standard::show(){
     local _name="$1"
     local _format="$2"
-    local _id _vlan _ports _addr _mtu _priv
+    local _id _vlan _ports _addr _addr6 _mtu _priv
 
     switch::find "_id" "${_name}"
     config::core::get "_ports" "ports_${_name}"
     config::core::get "_vlan" "vlan_${_name}"
     config::core::get "_addr" "addr_${_name}"
+    config::core::get "_addr6" "addr6_${_name}"
     config::core::get "_mtu" "mtu_${_name}"
     config::core::get "_priv" "private_${_name}" "no"
 
-    printf "${_format}" "${_name}" "standard" "${_id:--}" "${_addr:--}" "${_priv}" "${_mtu:--}" \
+    printf "${_format}" "${_name}" "standard" "${_id:--}" "${_addr:--}" "${_addr6:--}" "${_priv}" "${_mtu:--}" \
       "${_vlan:--}" "${_ports:--}"
 }
 
@@ -79,6 +80,7 @@ switch::standard::create(){
     [ -n "${_if}" ] && config::core::set "ports_${_switch}" "${_if}"
     [ -n "${_vlan}" ] && config::core::set "vlan_${_switch}" "${_vlan}"
     [ -n "${_addr}" ] && config::core::set "addr_${_switch}" "${_addr}"
+    [ -n "${_addr6}" ] && config::core::set "addr6_${_switch}" "${_addr6}"
     [ -n "${_priv}" ] && config::core::set "private_${_switch}" "${_priv}"
     [ -n "${_mtu}" ] && config::core::set "mtu_${_switch}" "${_mtu}"
 
@@ -164,7 +166,7 @@ switch::standard::vlan(){
 
 # set or remove ip address
 #
-# @param string _swtich name of the switch
+# @param string _switch name of the switch
 # @param string _addr address or "none"
 # @scope _id switch if from parent switch::address
 #
@@ -184,6 +186,31 @@ switch::standard::address(){
 
         config::core::set "addr_${_switch}" "${_addr}"
         ifconfig "${_id}" "${_addr}"
+    fi
+}
+
+# set or remove ipv6 address
+#
+# @param string _switch name of the switch
+# @param string _addr6 address or "none"
+# @scope _id switch if from parent switch::address
+#
+switch::standard::address6(){
+    local _switch="$1"
+    local _addr6="$2"
+    local _curr
+
+    if [ "${_addr6}" = "none" ]; then
+
+        config::core::get "_curr" "addr6_${_switch}"
+        [ $? -eq 0 ] || util::err "unable to locate an existing address for this switch"
+
+        config::core::remove "addr6_${_switch}"
+        ifconfig "${_id}" inet6 "${_curr}" delete
+    else
+
+        config::core::set "addr6_${_switch}" "${_addr6}"
+        ifconfig "${_id}" inet6 "${_addr6}" auto_linklocal
     fi
 }
 


### PR DESCRIPTION
Make it possible to create a switch with an IPv6 Address
`vm switch create -6 2001:1a:2b:3c:4d::1/64 switchname`

Also adds the option to add and remove the IPv6 Later with:
`vm switch address6 switchname 2001:1a:2b:3c:4d::1/64`
`vm switch address6 switchname none`

Additionally the vm switch list commands now has a ADDRESS6 Column