### PR TITLE
add grub_run_no_partition option to generate correct grub.conf

### DIFF
--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -100,8 +100,15 @@ guest::load(){
                 util::log_and_write "write" "${_name}" "device.map" "(hd0) ${_bootdisk}"
                 guest::__map_all_disks
 
-                config::get "_grub_opt" "grub_run_partition"
-                [ -n "${_grub_opt}" ] && _root="hd0,${_grub_opt}"
+                # generate right grub.conf when the disk does not use any partition
+                # like some cloud images
+                config::get "_grub_opt" "grub_run_no_partition"
+                if [ -n "${_grub_opt}" ]; then
+                    _root="hd0"
+                else
+                    config::get "_grub_opt" "grub_run_partition"
+                    [ -n "${_grub_opt}" ] && _root="hd0,${_grub_opt}"
+                fi
 
                 # if we have local config, point grub-bhyve at it
                 # otherwise we use defaults, or directory and file specified by user

--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -102,7 +102,7 @@ guest::load(){
 
                 # generate right grub.conf when the disk does not use any partition
                 # like some cloud images
-                if [ -n "${_grub_opt}" ]; then
+                if [ config::yesno "grub_run_no_partition" ]; then
                     _root="hd0"
                 else
                     config::get "_grub_opt" "grub_run_partition"

--- a/lib/vm-guest
+++ b/lib/vm-guest
@@ -102,7 +102,6 @@ guest::load(){
 
                 # generate right grub.conf when the disk does not use any partition
                 # like some cloud images
-                config::get "_grub_opt" "grub_run_no_partition"
                 if [ -n "${_grub_opt}" ]; then
                     _root="hd0"
                 else

--- a/vm.8
+++ b/vm.8
@@ -1565,6 +1565,15 @@ Specify the partition that grub should look in for the grub configuration
 files.
 By default, vm-bhyve will specify partition 1, which is correct in most
 standard cases.
+.It grub_run_no_partition
+Set this option to boot from an unpartitioned disk, as commonly found with
+cloud images where the filesystem is written directly to the raw disk.
+When enabled, the GRUB root device is set to
+.Sy hd0
+instead of
+.Sy hd0,X .
+This option takes precedence over
+.Sy grub_run_partition .
 .It grub_runX
 The option allows you to specify the grub commands needed to boot the guest
 from disk.


### PR DESCRIPTION
Its common cloud images provide unpartitioned disks.
This add an option that generate grub.conf that allow boot using unpartitioned disks.