### PR TITLE
vm-zfs: updated regex for specify options

### DIFF
--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -118,7 +118,7 @@ zfs::__format_options(){
     local _c_opts="$2"
 
     if [ -n "${_c_opts}" ]; then
-        _c_opts=$(echo "${_c_opts}" |sed -e 's/\ / -o /')
+        _c_opts=$(echo "${_c_opts}" |sed -E -e 's/[ \t]+/ -o /g')
         _c_opts="-o ${_c_opts}"
         setvar "${_val}" "${_c_opts}"
         return 0

--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -118,7 +118,7 @@ zfs::__format_options(){
     local _c_opts="$2"
 
     if [ -n "${_c_opts}" ]; then
-        _c_opts=$(echo "${_c_opts}" |sed -E -e 's/[ \t]+/ -o /g')
+        _c_opts=$(echo "${_c_opts}" | sed -E -e 's/^[ \t]+|[ \t]+$//g; s/[ \t]+/ -o /g; s/^/-o /')
         _c_opts="-o ${_c_opts}"
         setvar "${_val}" "${_c_opts}"
         return 0

--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -119,7 +119,6 @@ zfs::__format_options(){
 
     if [ -n "${_c_opts}" ]; then
         _c_opts=$(echo "${_c_opts}" | sed -E -e 's/^[ \t]+|[ \t]+$//g; s/[ \t]+/ -o /g; s/^/-o /')
-        _c_opts="-o ${_c_opts}"
         setvar "${_val}" "${_c_opts}"
         return 0
     fi


### PR DESCRIPTION
There's a replace regex in `zfs::__format_options()` supported one option only.

The proposal patch added `global` flag for supporting several options. Also added "tab-instead-space" handling.

Also see https://github.com/churchers/vm-bhyve/pull/590