### PR TITLE
vm-util: fix vmm module detection

### DIFF
--- a/lib/vm-util
+++ b/lib/vm-util
@@ -26,14 +26,21 @@ util::setup(){
 
 # load a kernel module
 #
-# @param string _mod the module name
+# @param string _mod the module name or filename
+# @param string _kind lookup mode, "mod" for module name or "file" for filename
 #
 util::load_module(){
     local _mod="$1"
-    kldstat -qm ${_mod} >/dev/null 2>&1
+    local _kind="${2:-mod}"
+
+    if [ "${_kind}" = "file" ]; then
+        kldstat -qn ${_mod} >/dev/null 2>&1
+    else
+        kldstat -qm ${_mod} >/dev/null 2>&1
+    fi
     if [ $? -ne 0 ]; then
         kldload ${_mod} >/dev/null 2>&1
-        [ $? -eq 0 ] || util::err "unable to load ${_mod}.ko!"
+        [ $? -eq 0 ] || util::err "unable to load ${_mod}!"
     fi
 }
 
@@ -54,7 +61,7 @@ util::check_bhyve_support(){
     # we do this here to make sure the sysctls exist, and before disable_host_checks
     # as we want this loaded anyway. FreeBSD version check removed as the
     # module won't exist on systems too old for bhyve
-    util::load_module "vmm"
+    util::load_module "vmm.ko" "file"
 
     # don't check if user wants to bypass host checks
     util::yesno "$vm_disable_host_checks" && return 0


### PR DESCRIPTION
Fixes a long-standing [bug](https://github.com/churchers/vm-bhyve/issues/322).

As seen below, the method to use `kdlstat -qm vmm` does not actually catch the loaded `vmm.ko` module. For some reason, `kldstat -qn vmm` or the more verbose `kldstat -qn vmm.ko` does. Without much change, I added a way to use the `-qn` flag for `vmm` specifically, but not for other modules that would break using the `-qn` flag (`nmdm`, `if_bridge`, `if_tuntap`, `if_tap`).

```bash
$ kldstat
Id Refs Address                Size Name
 1   54 0xffffffff80200000  1f4daa0 kernel
 2    1 0xffffffff8214e000    1c708 geom_eli.ko
 3    1 0xffffffff8216b000   620c10 zfs.ko
 4    1 0xffffffff83310000     3390 acpi_wmi.ko
 5    1 0xffffffff83314000     21e8 hcons.ko
 6    2 0xffffffff83317000     30a8 hidmap.ko
 7    1 0xffffffff8331b000     21e8 hsctrl.ko
 8    1 0xffffffff8331e000     4250 ichsmb.ko
 9    1 0xffffffff83323000     2178 smbus.ko
10    1 0xffffffff83326000     2110 pchtherm.ko
11    1 0xffffffff83329000     2a80 mac_ntpd.ko
12    2 0xffffffff8332c000    64bc8 pf.ko
13    1 0xffffffff83391000     21e8 pflog.ko
14    1 0xffffffff83400000   340438 vmm.ko
$ kldstat -qm vmm
$ echo "$?"
1
$ kldstat -qn vmm
$ echo "$?"
0
```

Although the issue I linked talks about FreeBSD version 12.0, it very much still persists on newer versions:

```bash
FreeBSD ******** 15.0-RELEASE FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC amd64
```