### PR TITLE
fix: correct typos in man page, README, config sample, and lib files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some additional packages may be required in certain circumstances:
 * `sysutils/grub2-bhyve` is required to run guests that need a Grub bootloader
 * `sysutils/bhyve-firmware` is required to run UEFI guests
 * `sysutils/tmux` is needed to use tmux console access instead of cu/nmdm
-* `net-mgmt/gnu-ipcalc` performs stricter CIDR notation vailidation when available
+* `net-mgmt/gnu-ipcalc` performs stricter CIDR notation validation when available
 
 ### See the GitHub wiki for more information and examples
 
@@ -59,7 +59,7 @@ See the sections below for more in-depth details.
     12. vm console myguest
 
 - [ ] Line 1
-Install vm-bhvye
+Install vm-bhyve
 
 - [ ] Line 2
 Create a dataset for your virtual machines.
@@ -124,7 +124,7 @@ Or with ZFS:
 
 This directory will be referred to as $vm_dir in the rest of this readme.
 
-Now run the following command to create the directories used to store vm-bhvye configuration and
+Now run the following command to create the directories used to store vm-bhyve configuration and
 load any necessary kernel modules. This needs to be run once after each host reboot, which is
 normally handled by the rc.d script
 

--- a/lib/vm-migration
+++ b/lib/vm-migration
@@ -36,7 +36,7 @@ migration::run(){
     _host="$2"
 
     # do we want to output our config?
-    # sender uses the config option to pull config from the recieve end
+    # sender uses the config option to pull config from the receive end
     if [ -n "${_config}" ]; then
         migration::__check_config "${_ds}"
         exit

--- a/lib/vm-zfs
+++ b/lib/vm-zfs
@@ -419,7 +419,7 @@ zfs::image_provision(){
     # get the datastore to create on
     datastore::get "${_datastore}" || util::err "unable to locate datastore '${_datastore}'"
 
-    # try to recieve
+    # try to receive
     echo "Unpacking guest image, this may take some time..."
 
     # check format of image
@@ -433,7 +433,7 @@ zfs::image_provision(){
     esac
 
     # error unpacking?
-    [ $? -eq 0 ] || util::err "errors occured while trying to unpackage the image file"
+    [ $? -eq 0 ] || util::err "errors occurred while trying to unpackage the image file"
 
     # remove the original snapshot
     zfs destroy -r "${VM_DS_ZFS_DATASET}/${_name}@${_uuid%%-*}" >/dev/null 2>&1

--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -358,7 +358,7 @@ graphics_listen="10.0.0.1"
 
 # graphics_res
 # This allows you to specify a resolution for the graphical console.
-# Pleas note only the below options are supported
+# Please note only the below options are supported
 #
 # Default: 800x600
 # Valid Options: 1920x1200,1920x1080,1600x1200,1600x900,1280x1024,1280x720,1024x768,800x600,640x480
@@ -409,11 +409,11 @@ xhci_mouse="yes"
 # only supports virtio consoles configured in this way
 #
 # For guests with named console support (FreeBSD 12+, Linux?), the
-# value can be the name of the port to create. The name "org.freenas.byhve-agent"
+# value can be the name of the port to create. The name "org.freenas.bhyve-agent"
 # can be useful as it ties in with tools written to make use of the
 # FreeNAS bhyve-agent interface.
 #
-virt_console0="org.freenas.byhve-agent"
+virt_console0="org.freenas.bhyve-agent"
 
 # grub_install0
 # use this to specify grub commands that should be run inside the
@@ -443,7 +443,7 @@ grub_run_partition="msdos1"
 
 # grub_run_dir
 # by default grub-bhyve will look in /boot/grub for the guests
-# grub config file. use this to specify an alterate path
+# grub config file. use this to specify an alternate path
 #
 # Default: /boot/grub (set by grub-bhyve)
 #

--- a/vm.8
+++ b/vm.8
@@ -263,7 +263,7 @@ is installed, create the directory which will store your virtual machine
 configuration and data.
 This directory will be referred to as
 .Pa $vm_dir
-throughput this man page.
+throughout this man page.
 .Pp
 Add the following into
 .Pa /etc/rc.conf
@@ -459,7 +459,7 @@ can be used to retrieve all user configurable settings, or you can specify one
 or more settings by name, separated by a space.
 .It Cm set Ar setting=value
 Sets the value of a global configuration setting.
-Multiple settings can be changed at the same time by seperating the
+Multiple settings can be changed at the same time by separating the
 .Sy setting=value
 pairs with a space.
 .Pp
@@ -566,7 +566,7 @@ CIDR notation.
 .It Fl p
 Use this option to create a private switch.
 If this is enabled, no traffic will be allowed between guests on the same
-switch, however then will all be able to communicate with any physical
+switch, however they will all be able to communicate with any physical
 interfaces added to the switch.
 .El
 .It Cm switch vlan Ar name Ar vlan-id
@@ -604,7 +604,7 @@ daemon.
 If DHCP is desired, we recommend using a manual switch and configuring this by
 hand.
 .It Cm switch private Ar name Ar on|off
-Enable of disable private mode for a virtual switch.
+Enable or disable private mode for a virtual switch.
 In private mode, guests will only be able to communicate with the physical
 interface(s), not with each other.
 .Pp
@@ -759,7 +759,7 @@ If the
 .Ar -t
 option and a
 .Ar tag
-is speficied, only guests with the specified tag are listed.
+is specified, only guests with the specified tag are listed.
 .It Cm info Op Ar name Op Ar ...
 Shows detailed information about the specified virtual machine(s).
 If no names are given, information for all virtual machines is displayed.
@@ -825,7 +825,7 @@ subcommand to connect to it if required.
 For each network adapter specified in the guest configuration, a
 .Xr tap 4
 interface will be created.
-If possible, the tap interface will be attached the relevant
+If possible, the tap interface will be attached to the relevant
 .Xr bridge 4
 interface, based on the virtual switch specified in the guest configuration.
 .Pp
@@ -1010,7 +1010,7 @@ to give each guest a chance to fully boot before the next starts.
 Stop all running virtual machines.
 This sends a stop command to all
 .Xr bhyve 8
-instances, regardless of whether they were starting using or not.
+instances, regardless of whether they were started using vm or not.
 .Pp
 If the
 .Ar -f
@@ -1149,7 +1149,7 @@ This will take a full snapshot of the local guest and send it to the destination
 host.
 .It Fl 2
 Run only the second stage.
-This will second an incremental snapshot and then complete the migration.
+This will send an incremental snapshot and then complete the migration.
 This requires the
 .Fl i
 parameter to specify the source snapshot.
@@ -1761,7 +1761,7 @@ Set this option to
 .Sy yes
 in order to provide an XHCI mouse device to the guest.
 This tracks much better than the default PS2 mouse in VNC settings, although
-this mouse may not supported by older guests.
+this mouse may not be supported by older guests.
 .It sound
 Set this option to
 .Sy yes
@@ -1879,7 +1879,7 @@ updated manually.
 .Pp
 On some systems it has been observed that bridging can cause interfaces to go
 down for up to 10 seconds, which is enough to stall ssh sessions.
-This is noticable when the first guest is started or when the last guest is
+This is noticeable when the first guest is started or when the last guest is
 stopped.
 Once there are at least 2 interfaces bridged (one real interface and a tap
 interface), further guests can be started/stopped without issue.


### PR DESCRIPTION
Fixes various typos found across documentation, man page, configuration sample, and library files

- README.md: vailidation, vm-bhvye
- vm.8: throughput/throughout, seperating, then/they, Enable of/or disable, speficied, attached the/to the, starting using/started using, second/send, may not supported/may not be supported, noticable/noticeable
- sample-templates/config.sample: Pleas, byhve-agent, alterate
- lib/vm-zfs: recieve, occured
- lib/vm-migration: recieve