### PR TITLE
fix: vm iso return find: -printf: unknown primary or operator

### DIFF
--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -448,8 +448,8 @@ datastore::iso_list(){
 
     # look for default iso location
     [ -d "${vm_dir}/.iso" ] && \
-        find "${vm_dir}/.iso" -type f -maxdepth 1 -printf "%f\n" | \
-        awk '{printf "'${_format}'","default",$1}'
+        find "${vm_dir}/.iso" -type f -maxdepth 1 | \
+        awk -F '/' '{printf "'${_format}'","default",$NF}'
 
     # look for iso datastores
     for _ds in ${VM_DATASTORE_LIST}; do
@@ -457,9 +457,8 @@ datastore::iso_list(){
         [ "${_spec%%:*}" != "iso" ] && continue
 
         [ -d "${_spec#*:}" ] && \
-            ls -1 ${_spec#*:} | \
-            find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
-            awk '{printf "'${_format}'","'${_ds}'",$1}'
+            find ${_spec#*:} -type f -maxdepth 1 | \
+            awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
     done
 }
 
@@ -472,8 +471,8 @@ datastore::img_list(){
 
     # look for default img location
     [ -d "${vm_dir}/.img" ] && \
-        find "${vm_dir}/.img" -type f -maxdepth 1 -printf "%f\n" | \
-        awk '{printf "'${_format}'","default",$1}'
+        find "${vm_dir}/.img" -type f -maxdepth 1 | \
+        awk -F '/' '{printf "'${_format}'","default",$NF}'
 
     # look for img datastores
     for _ds in ${VM_DATASTORE_LIST}; do
@@ -481,7 +480,7 @@ datastore::img_list(){
         [ "${_spec%%:*}" != "img" ] && continue
 
         [ -d "${_spec#*:}" ] && \
-            find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
-            awk '{printf "'${_format}'","'${_ds}'",$1}'
+            find ${_spec#*:} -type f -maxdepth 1 | \
+            awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
     done
 }

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -446,20 +446,33 @@ datastore::iso_list(){
 
     printf "${_format}" "DATASTORE" "FILENAME"
 
-    # look for default iso location
-    [ -d "${vm_dir}/.iso" ] && \
-        find "${vm_dir}/.iso" -type f -maxdepth 1 | \
-        awk -F '/' '{printf "'${_format}'","default",$NF}'
+    if [ "${VERSION_BSD#14}" != "${VERSION_BSD}" ]; then
+        [ -d "${vm_dir}/.iso" ] && \
+            find "${vm_dir}/.iso" -type f -maxdepth 1 | \
+            awk -F '/' '{printf "'${_format}'","default",$NF}'
 
-    # look for iso datastores
-    for _ds in ${VM_DATASTORE_LIST}; do
-        config::core::get "_spec" "path_${_ds}"
-        [ "${_spec%%:*}" != "iso" ] && continue
+        for _ds in ${VM_DATASTORE_LIST}; do
+            config::core::get "_spec" "path_${_ds}"
+            [ "${_spec%%:*}" != "iso" ] && continue
 
-        [ -d "${_spec#*:}" ] && \
-            find ${_spec#*:} -type f -maxdepth 1 | \
-            awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
-    done
+            [ -d "${_spec#*:}" ] && \
+                find ${_spec#*:} -type f -maxdepth 1 | \
+                awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
+        done
+    else
+        [ -d "${vm_dir}/.iso" ] && \
+            find "${vm_dir}/.iso" -type f -maxdepth 1 -printf "%f\n" | \
+            awk '{printf "'${_format}'","default",$1}'
+
+        for _ds in ${VM_DATASTORE_LIST}; do
+            config::core::get "_spec" "path_${_ds}"
+            [ "${_spec%%:*}" != "iso" ] && continue
+
+            [ -d "${_spec#*:}" ] && \
+                find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
+                awk '{printf "'${_format}'","'${_ds}'",$1}'
+        done
+    fi
 }
 
 # list img files
@@ -469,18 +482,31 @@ datastore::img_list(){
 
     printf "${_format}" "DATASTORE" "FILENAME"
 
-    # look for default img location
-    [ -d "${vm_dir}/.img" ] && \
-        find "${vm_dir}/.img" -type f -maxdepth 1 | \
-        awk -F '/' '{printf "'${_format}'","default",$NF}'
+    if [ "${VERSION_BSD#14}" != "${VERSION_BSD}" ]; then
+        [ -d "${vm_dir}/.img" ] && \
+            find "${vm_dir}/.img" -type f -maxdepth 1 | \
+            awk -F '/' '{printf "'${_format}'","default",$NF}'
 
-    # look for img datastores
-    for _ds in ${VM_DATASTORE_LIST}; do
-        config::core::get "_spec" "path_${_ds}"
-        [ "${_spec%%:*}" != "img" ] && continue
+        for _ds in ${VM_DATASTORE_LIST}; do
+            config::core::get "_spec" "path_${_ds}"
+            [ "${_spec%%:*}" != "img" ] && continue
 
-        [ -d "${_spec#*:}" ] && \
-            find ${_spec#*:} -type f -maxdepth 1 | \
-            awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
-    done
+            [ -d "${_spec#*:}" ] && \
+                find ${_spec#*:} -type f -maxdepth 1 | \
+                awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
+        done
+    else
+        [ -d "${vm_dir}/.img" ] && \
+            find "${vm_dir}/.img" -type f -maxdepth 1 -printf "%f\n" | \
+            awk '{printf "'${_format}'","default",$1}'
+
+        for _ds in ${VM_DATASTORE_LIST}; do
+            config::core::get "_spec" "path_${_ds}"
+            [ "${_spec%%:*}" != "img" ] && continue
+
+            [ -d "${_spec#*:}" ] && \
+                find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
+                awk '{printf "'${_format}'","'${_ds}'",$1}'
+        done
+    fi
 }

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -452,7 +452,7 @@ datastore::iso_list(){
     # list all configured iso datastores
     for _ds in ${VM_DATASTORE_LIST}; do
         config::core::get "_spec" "path_${_ds}"
-        [ "${_spec%%:*}" = "iso" ] || continue
+        [ "${_spec%%:*}" != "iso" ] && continue
 
         datastore::__list_files "${_ds}" "${_spec#*:}" "${_format}"
     done
@@ -471,7 +471,7 @@ datastore::img_list(){
     # list all configured img datastores
     for _ds in ${VM_DATASTORE_LIST}; do
         config::core::get "_spec" "path_${_ds}"
-        [ "${_spec%%:*}" = "img" ] || continue
+        [ "${_spec%%:*}" != "img" ] && continue
 
         datastore::__list_files "${_ds}" "${_spec#*:}" "${_format}"
     done

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -468,7 +468,7 @@ datastore::img_list(){
     # list "default" datastore
     datastore::__list_files "default" "${vm_dir}/.img" "${_format}"
 
-    # list all configured iso datastores
+    # list all configured img datastores
     for _ds in ${VM_DATASTORE_LIST}; do
         config::core::get "_spec" "path_${_ds}"
         [ "${_spec%%:*}" = "img" ] || continue

--- a/lib/vm-datastore
+++ b/lib/vm-datastore
@@ -446,33 +446,16 @@ datastore::iso_list(){
 
     printf "${_format}" "DATASTORE" "FILENAME"
 
-    if [ "${VERSION_BSD#14}" != "${VERSION_BSD}" ]; then
-        [ -d "${vm_dir}/.iso" ] && \
-            find "${vm_dir}/.iso" -type f -maxdepth 1 | \
-            awk -F '/' '{printf "'${_format}'","default",$NF}'
+    # list "default" datastore
+    datastore::__list_files "default" "${vm_dir}/.iso" "${_format}"
 
-        for _ds in ${VM_DATASTORE_LIST}; do
-            config::core::get "_spec" "path_${_ds}"
-            [ "${_spec%%:*}" != "iso" ] && continue
+    # list all configured iso datastores
+    for _ds in ${VM_DATASTORE_LIST}; do
+        config::core::get "_spec" "path_${_ds}"
+        [ "${_spec%%:*}" = "iso" ] || continue
 
-            [ -d "${_spec#*:}" ] && \
-                find ${_spec#*:} -type f -maxdepth 1 | \
-                awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
-        done
-    else
-        [ -d "${vm_dir}/.iso" ] && \
-            find "${vm_dir}/.iso" -type f -maxdepth 1 -printf "%f\n" | \
-            awk '{printf "'${_format}'","default",$1}'
-
-        for _ds in ${VM_DATASTORE_LIST}; do
-            config::core::get "_spec" "path_${_ds}"
-            [ "${_spec%%:*}" != "iso" ] && continue
-
-            [ -d "${_spec#*:}" ] && \
-                find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
-                awk '{printf "'${_format}'","'${_ds}'",$1}'
-        done
-    fi
+        datastore::__list_files "${_ds}" "${_spec#*:}" "${_format}"
+    done
 }
 
 # list img files
@@ -482,31 +465,36 @@ datastore::img_list(){
 
     printf "${_format}" "DATASTORE" "FILENAME"
 
+    # list "default" datastore
+    datastore::__list_files "default" "${vm_dir}/.img" "${_format}"
+
+    # list all configured iso datastores
+    for _ds in ${VM_DATASTORE_LIST}; do
+        config::core::get "_spec" "path_${_ds}"
+        [ "${_spec%%:*}" = "img" ] || continue
+
+        datastore::__list_files "${_ds}" "${_spec#*:}" "${_format}"
+    done
+
+}
+
+# print each file in a directory prefixed with its datastore name
+# @param string _name   datastore name to display
+# @param string _dir    directory to scan
+# @param string _format printf format string
+#
+datastore::__list_files(){
+    local _name="$1" _dir="$2" _format="$3" _file
+
+    [ -d "${_dir}" ] || return 0
+
     if [ "${VERSION_BSD#14}" != "${VERSION_BSD}" ]; then
-        [ -d "${vm_dir}/.img" ] && \
-            find "${vm_dir}/.img" -type f -maxdepth 1 | \
-            awk -F '/' '{printf "'${_format}'","default",$NF}'
-
-        for _ds in ${VM_DATASTORE_LIST}; do
-            config::core::get "_spec" "path_${_ds}"
-            [ "${_spec%%:*}" != "img" ] && continue
-
-            [ -d "${_spec#*:}" ] && \
-                find ${_spec#*:} -type f -maxdepth 1 | \
-                awk -F '/' '{printf "'${_format}'","'${_ds}'",$NF}'
+        find "${_dir}" -maxdepth 1 -type f | while read -r _file; do
+            printf "${_format}" "${_name}" "${_file##*/}"
         done
     else
-        [ -d "${vm_dir}/.img" ] && \
-            find "${vm_dir}/.img" -type f -maxdepth 1 -printf "%f\n" | \
-            awk '{printf "'${_format}'","default",$1}'
-
-        for _ds in ${VM_DATASTORE_LIST}; do
-            config::core::get "_spec" "path_${_ds}"
-            [ "${_spec%%:*}" != "img" ] && continue
-
-            [ -d "${_spec#*:}" ] && \
-                find ${_spec#*:} -type f -maxdepth 1 -printf "%f\n" | \
-                awk '{printf "'${_format}'","'${_ds}'",$1}'
+        find "${_dir}" -maxdepth 1 -type f -printf "%f\n" | while read -r _file; do
+            printf "${_format}" "${_name}" "${_file}"
         done
     fi
 }


### PR DESCRIPTION
Running on FreeBSD 14.4, the command "vm iso" return an error.

It seems that the option "-printf" doesn't exist in find under FreeBSD 14.4.

So I've fix the "vm iso" ans "vm img" with this patch.

Any comments are welcome.

Best regards
Hugues