### PR TITLE
Fix error in man page

### DIFF
--- a/vm.8
+++ b/vm.8
@@ -710,7 +710,7 @@ Unless specified, the guest image will be a sparse file 20GB in size.
 .It Fl c Ar vCPUs
 Override the number of vCPUs allocated to the guest as specified in the
 template.
-.It Fl c Ar memory
+.It Fl m Ar memory
 Override the amount of memory allocated to the guest as specified in the
 template.
 .It Fl i Ar vm-image


### PR DESCRIPTION
The `create` `-m` option was erroneously listed as `-c`.