### PR TITLE
README.md: Fix capitalization of FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ that are supported at the time of its release.  See also
 
 ## Quick-Start
 
-A simple overview of the commands needed to install vm-bhyve and start a freebsd guest.
+A simple overview of the commands needed to install vm-bhyve and start a FreeBSD guest.
 See the sections below for more in-depth details.
 
     1. pkg install vm-bhyve


### PR DESCRIPTION
Correct a lowercase instance of 'freebsd' to 'FreeBSD' in the README.